### PR TITLE
Displaying authorship on articles

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -19,8 +19,9 @@
     {% endif %}
     <h1 id="{{ article.slug }}">{{ article.title }}</h1>
     <p>
-      {{ _('Posted on %(when)s in %(category)s',
+      {{ _('Posted on %(when)s in %(category)s by %(author)s',
            when=article.locale_date,
+           author=article.author.name,
            category='<a href="%s/%s">%s</a>'|format(SITEURL, article.category.url, article.category)|safe) }}
 
       {% if 'post_stats' in PLUGINS %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,8 +17,9 @@
   <header>
     <h2><a href="{{ SITEURL }}/{{ article.url }}{% if not DISABLE_URL_HASH %}#{{ article.slug }}{% endif %}">{{ article.title }}</a></h2>
     <p>
-      {{ _('Posted on %(when)s in %(category)s',
+      {{ _('Posted on %(when)s in %(category)s by %(author)s',
            when=article.locale_date,
+           author=article.author.name,
            category='<a href="%s/%s">%s</a>'|format(SITEURL, article.category.url, article.category)|safe) }}
 
       {% if article.tags and not HOME_HIDE_TAGS %}


### PR DESCRIPTION
Besides the obvious display in the main article page and in
the category page, here are two other effects

- the default author defined in `pelicanconf.py` will be
  displayed. In Octobus usage (https://heptapod.net), that's probably
  a good thing
- translation probably doesn't exist for the new "Posted on…" line,
  but that doesn't matter for Octobus usage (it's all English anyway).